### PR TITLE
[BB-664] & [BB-743] Future Jobs Permissions included to the sync process

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # `baton-greenhouse` [![Go Reference](https://pkg.go.dev/badge/github.com/conductorone/baton-greenhouse.svg)](https://pkg.go.dev/github.com/conductorone/baton-greenhouse) ![main ci](https://github.com/conductorone/baton-greenhouse/actions/workflows/main.yaml/badge.svg)
 
-`baton-greenhouse` is a connector for built using the [Baton SDK](https://github.com/conductorone/baton-sdk).
+`baton-greenhouse` is a connector for [Greenhouse](https://www.greenhouse.com/) built using the [Baton SDK](https://github.com/conductorone/baton-sdk).
 
 Check out [Baton](https://github.com/conductorone/baton) to learn more the project in general.
 
@@ -14,7 +14,7 @@ To use this connector you need to provide an API key from the Harvest API. Go to
 
 ```
 brew install conductorone/baton/baton conductorone/baton/baton-greenhouse
-baton-greenhouse
+baton-greenhouse --username=API_TOKEN
 baton resources
 ```
 
@@ -31,7 +31,7 @@ docker run --rm -v $(pwd):/out ghcr.io/conductorone/baton:latest -f "/out/sync.c
 go install github.com/conductorone/baton/cmd/baton@main
 go install github.com/conductorone/baton-greenhouse/cmd/baton-greenhouse@main
 
-baton-greenhouse
+baton-greenhouse --username=API_TOKEN
 
 baton resources
 ```
@@ -39,7 +39,9 @@ baton resources
 # Data Model
 
 `baton-greenhouse` will pull down information about the following resources:
-- Users
+  - Users
+  - Roles for Job Permissions
+  - Roles for Future Job Permissions
 
 # Contributing, Support and Issues
 

--- a/docs/docs-info
+++ b/docs/docs-info
@@ -5,13 +5,15 @@ While developing the connector, please fill out this form. This information is n
 1. What resources does the connector sync?
 
    This connector syncs:
-      -Users
+      - Users
+      - Roles for Job Permissions
+      - Roles for Future Job Permissions
 
 2. Can the connector provision any resources? If so, which ones? 
 
-   -Yes, this update includes account provisioning.
+   - Yes, this update includes account provisioning.
    Note: The new User will have Basic permissions
-   -Also, this update includes revoke site admin permission from existing users
+   - Also, this update includes revoke site admin permission from existing users
    Note: You can't revoke permission from a non-human identity or from yourself
 
 ## Connector credentials 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,6 +21,9 @@ const (
 	userRolesEPv1                = "v1/user_roles"
 	userJobPermissionsEPv1       = "v1/users/%d/permissions/jobs"
 	userFutureJobPermissionsEPv1 = "v1/users/%d/permissions/future_jobs"
+
+	// RequestCompleted is a placeholder for the PermissionsToken when the query is completed.
+	RequestCompleted = "request_completed_no_more_pages"
 )
 
 type GreenhouseClient struct {
@@ -197,124 +200,122 @@ func (c *GreenhouseClient) GetUserByEmail(ctx context.Context, email string) (*m
 // and/or 'Interviewer' users, as these roles are assigned on a per-job basis.
 // Users that are 'Site Admins' have permissions on all public jobs and will return an empty array.
 // 'Basic users' cannot be assigned to any jobs and will also return an empty array.
-//
-// This function handles pagination.
-func (c *GreenhouseClient) GetJobPermissionsOfAUser(ctx context.Context, userID int) ([]models.JobPermission, error) {
+func (c *GreenhouseClient) GetJobPermissionsOfAUser(ctx context.Context, tokens *JobPermissionPaginationTokens, userID int) ([]models.JobPermission, *v2.RateLimitDescription, error) {
 	var jobPermissions []models.JobPermission
-	nextPageURL := ""
-	rl := &v2.RateLimitDescription{}
+	var rateLimitData v2.RateLimitDescription
+	var queryURL string
+
+	if tokens.JobPermissionsToken == RequestCompleted {
+		return nil, nil, nil
+	}
 
 	endpointURL, err := url.JoinPath(baseURL, fmt.Sprintf(userJobPermissionsEPv1, userID))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	params := map[string]interface{}{
-		"per_page": 500,
-		"page":     1,
+	nextToken := tokens.JobPermissionsToken
+	if nextToken == "" {
+		params := map[string]interface{}{
+			"per_page": 500,
+			"page":     1,
+		}
+		queryURL, err = urlAddQuery(endpointURL, params)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		queryURL = nextToken
 	}
-	queryURL, err := urlAddQuery(endpointURL, params)
+
+	parsedURL, err := url.Parse(queryURL)
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("cannot parse URL, error: %w", err)
 	}
 
-	// TODO: Remove this 'inner' iteration and elevate the nextPageURL to the Grants function.
-	//  Handling pagination like this could be really problematic when errors or rate-limits occurs
-	// Iterating for pagination.
-	for {
-		var jobPermissionsPage []models.JobPermission
-		parsedURL, err := url.Parse(queryURL)
-		if err != nil {
-			return nil, fmt.Errorf("cannot parse URL, error: %w", err)
-		}
+	resp, err := c.doRequest(ctx, http.MethodGet, parsedURL, nil, nil, &jobPermissions, &rateLimitData)
+	if err != nil {
+		return nil, &rateLimitData, err
+	}
+	defer resp.Body.Close()
 
-		resp, err := c.doRequest(ctx, http.MethodGet, parsedURL, nil, nil, &jobPermissionsPage, rl)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-
-		// Pagination Docs https://developers.greenhouse.io/harvest.html#pagination
-		link := &models.Link{}
-		err = link.UnmarshalText([]byte(resp.Header.Get("Link")))
-		if err != nil {
-			return nil, fmt.Errorf("cannot unmarshal value of header Link, error: %w", err)
-		}
-
-		jobPermissions = append(jobPermissions, jobPermissionsPage...)
-		nextPageURL = link.Next
-		if nextPageURL == "" {
-			break
-		}
-
-		queryURL = nextPageURL
+	// Pagination Docs https://developers.greenhouse.io/harvest.html#pagination
+	link := &models.Link{}
+	err = link.UnmarshalText([]byte(resp.Header.Get("Link")))
+	if err != nil {
+		return nil, &rateLimitData, fmt.Errorf("cannot unmarshal value of header Link, error: %w", err)
 	}
 
-	return jobPermissions, nil
+	if link.Next == "" {
+		tokens.JobPermissionsToken = RequestCompleted
+	} else {
+		tokens.JobPermissionsToken = link.Next
+	}
+
+	return jobPermissions, &rateLimitData, nil
 }
 
 // GetFutureJobPermissionsOfAUser receives the ID of a User and requests all the Future Job Permissions it has.
 // Docs link: https://developers.greenhouse.io/harvest.html#get-list-future-job-permissions
-//
-// This function handles pagination.
-func (c *GreenhouseClient) GetFutureJobPermissionsOfAUser(ctx context.Context, userID int) ([]models.FutureJobPermission, error) {
+func (c *GreenhouseClient) GetFutureJobPermissionsOfAUser(ctx context.Context, tokens *JobPermissionPaginationTokens, userID int) ([]models.FutureJobPermission, *v2.RateLimitDescription, error) {
 	var futureJobPermissions []models.FutureJobPermission
-	nextPageURL := ""
-	rl := &v2.RateLimitDescription{}
+	var rateLimitData v2.RateLimitDescription
+	var queryURL string
+
+	if tokens.FutureJobPermissionsToken == RequestCompleted {
+		return nil, nil, nil
+	}
 
 	endpointURL, err := url.JoinPath(baseURL, fmt.Sprintf(userFutureJobPermissionsEPv1, userID))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	params := map[string]interface{}{
-		"per_page": 500,
-		"page":     1,
+	nextToken := tokens.FutureJobPermissionsToken
+	if nextToken == "" {
+		params := map[string]interface{}{
+			"per_page": 500,
+			"page":     1,
+		}
+		queryURL, err = urlAddQuery(endpointURL, params)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		queryURL = nextToken
 	}
-	queryURL, err := urlAddQuery(endpointURL, params)
+
+	parsedURL, err := url.Parse(queryURL)
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("cannot parse URL, error: %w", err)
 	}
 
-	// TODO: Remove this 'inner' iteration and elevate the nextPageURL to the Grants function.
-	//  Handling pagination like this could be really problematic when errors or rate-limits occurs
-	// Iterating for pagination.
-	for {
-		var futureJobPermissionsPage []models.FutureJobPermission
-		parsedURL, err := url.Parse(queryURL)
-		if err != nil {
-			return nil, fmt.Errorf("cannot parse URL, error: %w", err)
-		}
+	resp, err := c.doRequest(ctx, http.MethodGet, parsedURL, nil, nil, &futureJobPermissions, &rateLimitData)
+	if err != nil {
+		return nil, &rateLimitData, err
+	}
+	defer resp.Body.Close()
 
-		resp, err := c.doRequest(ctx, http.MethodGet, parsedURL, nil, nil, &futureJobPermissionsPage, rl)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-
-		// Pagination Docs https://developers.greenhouse.io/harvest.html#pagination
-		link := &models.Link{}
-		err = link.UnmarshalText([]byte(resp.Header.Get("Link")))
-		if err != nil {
-			return nil, fmt.Errorf("cannot unmarshal value of header Link, error: %w", err)
-		}
-
-		futureJobPermissions = append(futureJobPermissions, futureJobPermissionsPage...)
-		nextPageURL = link.Next
-		if nextPageURL == "" {
-			break
-		}
-
-		queryURL = nextPageURL
+	// Pagination Docs https://developers.greenhouse.io/harvest.html#pagination
+	link := &models.Link{}
+	err = link.UnmarshalText([]byte(resp.Header.Get("Link")))
+	if err != nil {
+		return nil, &rateLimitData, fmt.Errorf("cannot unmarshal value of header Link, error: %w", err)
 	}
 
-	return futureJobPermissions, nil
+	if link.Next == "" {
+		tokens.FutureJobPermissionsToken = RequestCompleted
+	} else {
+		tokens.FutureJobPermissionsToken = link.Next
+	}
+
+	return futureJobPermissions, &rateLimitData, nil
 }
 
 // ListUserRoles - Docs link: https://developers.greenhouse.io/harvest.html#get-list-user-roles
 func (c *GreenhouseClient) ListUserRoles(ctx context.Context, nextPageURL string) ([]models.UserRole, *v2.RateLimitDescription, string, error) {
 	var userRoles []models.UserRole
-	rl := &v2.RateLimitDescription{}
+	var rateLimitData v2.RateLimitDescription
 
 	endpointURL, err := url.JoinPath(baseURL, userRolesEPv1)
 	if err != nil {
@@ -338,9 +339,9 @@ func (c *GreenhouseClient) ListUserRoles(ctx context.Context, nextPageURL string
 		return nil, nil, "", fmt.Errorf("cannot parse URL, error: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodGet, parsedURL, nil, nil, &userRoles, rl)
+	resp, err := c.doRequest(ctx, http.MethodGet, parsedURL, nil, nil, &userRoles, &rateLimitData)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, &rateLimitData, "", err
 	}
 	defer resp.Body.Close()
 
@@ -351,31 +352,31 @@ func (c *GreenhouseClient) ListUserRoles(ctx context.Context, nextPageURL string
 		return nil, nil, "", fmt.Errorf("cannot unmarshal value of header Link, error: %w", err)
 	}
 
-	return userRoles, rl, link.Next, nil
+	return userRoles, &rateLimitData, link.Next, nil
 }
 
 // RetrieveUserData - Docs link: https://developers.greenhouse.io/harvest.html#get-retrieve-user
-func (c *GreenhouseClient) RetrieveUserData(ctx context.Context, userID string) (*models.User, error) {
+func (c *GreenhouseClient) RetrieveUserData(ctx context.Context, userID string) (*models.User, *v2.RateLimitDescription, error) {
 	var userData *models.User
-	rl := &v2.RateLimitDescription{}
+	var rateLimitData v2.RateLimitDescription
 
 	endpointURL, err := url.JoinPath(baseURL, usersEPv1, userID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	parsedURL, err := url.Parse(endpointURL)
 	if err != nil {
-		return nil, fmt.Errorf("cannot parse URL, error: %w", err)
+		return nil, nil, fmt.Errorf("cannot parse URL, error: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, http.MethodGet, parsedURL, nil, nil, &userData, rl)
+	resp, err := c.doRequest(ctx, http.MethodGet, parsedURL, nil, nil, &userData, &rateLimitData)
 	if err != nil {
-		return nil, err
+		return nil, &rateLimitData, err
 	}
 	defer resp.Body.Close()
 
-	return userData, nil
+	return userData, &rateLimitData, nil
 }
 
 // doRequest builds and sends an HTTP request to the Greenhouse API with the given method, URL,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,9 +17,10 @@ import (
 const (
 	baseURL = "https://harvest.greenhouse.io"
 
-	usersEPv1              = "v1/users"
-	userRolesEPv1          = "v1/user_roles"
-	userJobPermissionsEPv1 = "%d/permissions/jobs"
+	usersEPv1                    = "v1/users"
+	userRolesEPv1                = "v1/user_roles"
+	userJobPermissionsEPv1       = "v1/users/%d/permissions/jobs"
+	userFutureJobPermissionsEPv1 = "v1/users/%d/permissions/future_jobs"
 )
 
 type GreenhouseClient struct {
@@ -189,7 +190,7 @@ func (c *GreenhouseClient) GetUserByEmail(ctx context.Context, email string) (*m
 	return &user, nil
 }
 
-// GetJobPermissionsOfAUser receives the ID of a User and requests all the JobPermissions it has.
+// GetJobPermissionsOfAUser receives the ID of a User and requests all the Job Permissions it has.
 // Docs link: https://developers.greenhouse.io/harvest.html#get-list-job-permissions
 //
 // According to the documentation, this endpoint is only intended for use with 'Job Admin'
@@ -217,6 +218,8 @@ func (c *GreenhouseClient) GetJobPermissionsOfAUser(ctx context.Context, userID 
 		return nil, err
 	}
 
+	// TODO: Remove this 'inner' iteration and elevate the nextPageURL to the Grants function.
+	//  Handling pagination like this could be really problematic when errors or rate-limits occurs
 	// Iterating for pagination.
 	for {
 		var jobPermissionsPage []models.JobPermission
@@ -248,6 +251,64 @@ func (c *GreenhouseClient) GetJobPermissionsOfAUser(ctx context.Context, userID 
 	}
 
 	return jobPermissions, nil
+}
+
+// GetFutureJobPermissionsOfAUser receives the ID of a User and requests all the Future Job Permissions it has.
+// Docs link: https://developers.greenhouse.io/harvest.html#get-list-future-job-permissions
+//
+// This function handles pagination.
+func (c *GreenhouseClient) GetFutureJobPermissionsOfAUser(ctx context.Context, userID int) ([]models.FutureJobPermission, error) {
+	var futureJobPermissions []models.FutureJobPermission
+	nextPageURL := ""
+	rl := &v2.RateLimitDescription{}
+
+	endpointURL, err := url.JoinPath(baseURL, fmt.Sprintf(userFutureJobPermissionsEPv1, userID))
+	if err != nil {
+		return nil, err
+	}
+
+	params := map[string]interface{}{
+		"per_page": 500,
+		"page":     1,
+	}
+	queryURL, err := urlAddQuery(endpointURL, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Remove this 'inner' iteration and elevate the nextPageURL to the Grants function.
+	//  Handling pagination like this could be really problematic when errors or rate-limits occurs
+	// Iterating for pagination.
+	for {
+		var futureJobPermissionsPage []models.FutureJobPermission
+		parsedURL, err := url.Parse(queryURL)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse URL, error: %w", err)
+		}
+
+		resp, err := c.doRequest(ctx, http.MethodGet, parsedURL, nil, nil, &futureJobPermissionsPage, rl)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		// Pagination Docs https://developers.greenhouse.io/harvest.html#pagination
+		link := &models.Link{}
+		err = link.UnmarshalText([]byte(resp.Header.Get("Link")))
+		if err != nil {
+			return nil, fmt.Errorf("cannot unmarshal value of header Link, error: %w", err)
+		}
+
+		futureJobPermissions = append(futureJobPermissions, futureJobPermissionsPage...)
+		nextPageURL = link.Next
+		if nextPageURL == "" {
+			break
+		}
+
+		queryURL = nextPageURL
+	}
+
+	return futureJobPermissions, nil
 }
 
 // ListUserRoles - Docs link: https://developers.greenhouse.io/harvest.html#get-list-user-roles

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,9 +21,6 @@ const (
 	userRolesEPv1                = "v1/user_roles"
 	userJobPermissionsEPv1       = "v1/users/%d/permissions/jobs"
 	userFutureJobPermissionsEPv1 = "v1/users/%d/permissions/future_jobs"
-
-	// RequestCompleted is a placeholder for the PermissionsToken when the query is completed.
-	RequestCompleted = "request_completed_no_more_pages"
 )
 
 type GreenhouseClient struct {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -204,7 +204,7 @@ func (c *GreenhouseClient) GetJobPermissionsOfAUser(ctx context.Context, userID 
 	nextPageURL := ""
 	rl := &v2.RateLimitDescription{}
 
-	endpointURL, err := url.JoinPath(baseURL, usersEPv1, fmt.Sprintf(userJobPermissionsEPv1, userID))
+	endpointURL, err := url.JoinPath(baseURL, fmt.Sprintf(userJobPermissionsEPv1, userID))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/helpers.go
+++ b/pkg/client/helpers.go
@@ -11,6 +11,9 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 )
 
+// RequestCompleted is a placeholder for the PermissionsToken when the query is completed.
+const RequestCompleted = "request_completed_no_more_pages"
+
 var findNextURL = regexp.MustCompile(`\<([^>]+)\>`)
 
 func withBasicAuth(val string) uhttp.RequestOption {

--- a/pkg/client/helpers.go
+++ b/pkg/client/helpers.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	liburl "net/url"
 	"regexp"
@@ -44,4 +45,30 @@ func urlAddQuery(url string, params map[string]interface{}) (string, error) {
 func getNextLink(raw string) string {
 	found := strings.Replace(findNextURL.FindString(raw), "<", "", 1)
 	return strings.Replace(found, ">", "", 1)
+}
+
+// JobPermissionPaginationTokens
+// This pagination method could be modified to use the SDKs pagination bag instead.
+// Probably, that would be the best way to go. It's something to analyze.
+type JobPermissionPaginationTokens struct {
+	JobPermissionsToken       string
+	FutureJobPermissionsToken string
+}
+
+func SerializeTokens(tokens JobPermissionPaginationTokens) (string, error) {
+	b, err := json.Marshal(tokens)
+	if err != nil {
+		return "", fmt.Errorf("cannot serialize custom pagination tokens: %w", err)
+	}
+	return string(b), nil
+}
+
+func DeserializeTokens(stringToken string) (JobPermissionPaginationTokens, error) {
+	var tokens JobPermissionPaginationTokens
+	if stringToken == "" {
+		return tokens, nil
+	}
+
+	err := json.Unmarshal([]byte(stringToken), &tokens)
+	return tokens, fmt.Errorf("cannot deserialize custom pagination tokens: %w", err)
 }

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -37,10 +37,14 @@ func (b *roleBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 
 func (b *roleBuilder) List(ctx context.Context, _ *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	var roleResources []*v2.Resource
+	var outAnnotations annotations.Annotations
 	logger := ctxzap.Extract(ctx)
-	userRoles, rl, nextPageURL, err := b.client.ListUserRoles(ctx, pToken.Token)
+	userRoles, rateLimitData, nextPageURL, err := b.client.ListUserRoles(ctx, pToken.Token)
 	if err != nil {
-		return nil, "", nil, err
+		if rateLimitData != nil {
+			outAnnotations.WithRateLimiting(rateLimitData)
+		}
+		return nil, "", outAnnotations, err
 	}
 
 	for _, userRole := range userRoles {
@@ -96,10 +100,8 @@ func (b *roleBuilder) List(ctx context.Context, _ *v2.ResourceId, pToken *pagina
 
 	roleResources = append(roleResources, siteAdminResource)
 
-	var anno annotations.Annotations
-	anno.WithRateLimiting(rl)
-
-	return roleResources, nextPageURL, anno, nil
+	outAnnotations.WithRateLimiting(rateLimitData)
+	return roleResources, nextPageURL, outAnnotations, nil
 }
 
 func (b *roleBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -12,6 +12,8 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	resourceSdk "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 type roleBuilder struct {
@@ -24,6 +26,9 @@ const (
 	// User Roles can be type 'interviewer' or 'job_admin'.
 	roleTypeInterviewer = "interviewer"
 	roleTypeJobAdmin    = "job_admin"
+
+	// This is a constant used to map the Entitlement created for the Site Admins.
+	roleTypeSiteAdmin = "site_admin"
 )
 
 func (b *roleBuilder) ResourceType(_ context.Context) *v2.ResourceType {
@@ -32,7 +37,7 @@ func (b *roleBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 
 func (b *roleBuilder) List(ctx context.Context, _ *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	var roleResources []*v2.Resource
-
+	logger := ctxzap.Extract(ctx)
 	userRoles, rl, nextPageURL, err := b.client.ListUserRoles(ctx, pToken.Token)
 	if err != nil {
 		return nil, "", nil, err
@@ -47,15 +52,44 @@ func (b *roleBuilder) List(ctx context.Context, _ *v2.ResourceId, pToken *pagina
 		// TODO: Validate Display Name.
 		// Since we cannot test this, I'm not sure if the Name that comes in the response structure it's fine to have as Display Name
 		// or if we should add a prefix like "Job Admin:" and then the user role name.
-		newRoleResource, err := createRoleResource(strconv.Itoa(userRole.ID), userRole.Name, userRole.Type)
+		newRoleResource, err := createRoleResource(
+			strconv.Itoa(userRole.ID),
+			userRole.Name,
+			userRole.Type,
+		)
 		if err != nil {
+			logger.Debug(
+				fmt.Sprintf("Role resource creation failed. UserRoleID: %d; UserRoleType: %s", userRole.ID, userRole.Type),
+				zap.Error(err),
+			)
+			return nil, "", nil, err
+		}
+		roleResources = append(roleResources, newRoleResource)
+
+		// TODO: Validate Display Name.
+		// Create the entitlement for the future job permission.
+		// Structure: "future-job:userRoleID"
+		newRoleResource, err = createRoleResource(
+			fmt.Sprintf("future-job:%d", userRole.ID),
+			fmt.Sprintf("Future Job: %s", userRole.Name),
+			userRole.Type,
+		)
+		if err != nil {
+			logger.Debug(
+				fmt.Sprintf("Role resource (future-job) creation failed. UserRoleID: %d; UserRoleType: %s", userRole.ID, userRole.Type),
+				zap.Error(err),
+			)
 			return nil, "", nil, err
 		}
 		roleResources = append(roleResources, newRoleResource)
 	}
 
 	// Creates the Role Resource for the 'Site Admin'
-	siteAdminResource, err := createRoleResource("site_admin", "Site Admin", "site_admin")
+	siteAdminResource, err := createRoleResource(
+		"site_admin",
+		"Site Admin",
+		roleTypeSiteAdmin,
+	)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -108,10 +142,22 @@ func (b *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 	return nil, nil
 }
 
-func extractUniqueUserRolesIDs(jobPermissions []models.JobPermission) []int {
+func extractUniqueUserRolesIDs(permissionList interface{}) ([]int, error) {
 	userRoleIDs := make(map[int]struct{})
-	for _, jobPermission := range jobPermissions {
-		userRoleIDs[jobPermission.UserRoleID] = struct{}{}
+
+	switch sliceData := permissionList.(type) {
+	case []models.JobPermission:
+		for _, jobPermission := range sliceData {
+			userRoleIDs[jobPermission.UserRoleID] = struct{}{}
+		}
+
+	case []models.FutureJobPermission:
+		for _, futureJobPermission := range sliceData {
+			userRoleIDs[futureJobPermission.UserRoleID] = struct{}{}
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported data type: expected []StructA or []StructB, got %T", permissionList)
 	}
 
 	var IDs []int
@@ -119,7 +165,7 @@ func extractUniqueUserRolesIDs(jobPermissions []models.JobPermission) []int {
 		IDs = append(IDs, ID)
 	}
 
-	return IDs
+	return IDs, nil
 }
 
 func createRoleResource(roleID, name, roleType string) (*v2.Resource, error) {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -51,13 +51,20 @@ func (b *userBuilder) Entitlements(_ context.Context, _ *v2.Resource, _ *paginat
 }
 
 // Grants function will create the Grants for the Roles. This should upgrade performance and reduce sync time.
-func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
 	var roleGrants []*v2.Grant
+	var outAnnotations annotations.Annotations
 	userID := userResource.Id
 
-	user, err := b.client.RetrieveUserData(ctx, userResource.Id.Resource)
+	tokens, err := client.DeserializeTokens(pToken.Token)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("cannot retrieve user: %w", err)
+		return nil, "", nil, err
+	}
+
+	user, rateLimitData, err := b.client.RetrieveUserData(ctx, userResource.Id.Resource)
+	outAnnotations.WithRateLimiting(rateLimitData)
+	if err != nil {
+		return nil, "", outAnnotations, fmt.Errorf("cannot retrieve user: %w", err)
 	}
 
 	// If the user is a Site Admin, it should have that Grant and skip the other ones.
@@ -74,9 +81,11 @@ func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, _ *
 	} else {
 		// All the Job Permissions of the user will be requested in order to create a grant for any role
 		// for which the user has at least one Job with it.
-		userJobPermissions, err := b.client.GetJobPermissionsOfAUser(ctx, user.ID)
+		userJobPermissions, rateLimitData, err := b.client.GetJobPermissionsOfAUser(ctx, &tokens, user.ID)
+		outAnnotations = annotations.Annotations{}
+		outAnnotations.WithRateLimiting(rateLimitData)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, "", outAnnotations, err
 		}
 
 		uniqueUserRoleIDs, err := extractUniqueUserRolesIDs(userJobPermissions)
@@ -97,9 +106,11 @@ func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, _ *
 
 		// Retrieves the list of 'Future Job Permissions' assigned to the user.
 		// These are Job Permissions that will be granted to the user when a job is created in a particular Department/Office combination.
-		userFutureJobPermissions, err := b.client.GetFutureJobPermissionsOfAUser(ctx, user.ID)
+		userFutureJobPermissions, rateLimitData, err := b.client.GetFutureJobPermissionsOfAUser(ctx, &tokens, user.ID)
+		outAnnotations = annotations.Annotations{}
+		outAnnotations.WithRateLimiting(rateLimitData)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, "", outAnnotations, err
 		}
 
 		uniqueUserRoleIDs, err = extractUniqueUserRolesIDs(userFutureJobPermissions)
@@ -120,7 +131,17 @@ func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, _ *
 		}
 	}
 
-	return roleGrants, "", nil, nil
+	var nextToken string
+	if tokens.JobPermissionsToken == client.RequestCompleted && tokens.FutureJobPermissionsToken == client.RequestCompleted {
+		nextToken = ""
+	} else {
+		nextToken, err = client.SerializeTokens(tokens)
+		if err != nil {
+			return nil, "", outAnnotations, err
+		}
+	}
+
+	return roleGrants, nextToken, outAnnotations, nil
 }
 
 // CreateAccountCapabilityDetails returns the account provisioning capabilities of this connector.

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -24,10 +24,14 @@ func (b *userBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 
 func (b *userBuilder) List(ctx context.Context, _ *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
 	var userResources []*v2.Resource
+	var outAnnotations annotations.Annotations
 
-	users, rl, next, err := b.client.ListUsers(ctx, pToken.Token)
+	users, rateLimitData, next, err := b.client.ListUsers(ctx, pToken.Token)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("cannot list users, error: %w", err)
+		if rateLimitData != nil {
+			outAnnotations.WithRateLimiting(rateLimitData)
+		}
+		return nil, "", outAnnotations, fmt.Errorf("cannot list users, error: %w", err)
 	}
 
 	for _, user := range users {
@@ -39,10 +43,9 @@ func (b *userBuilder) List(ctx context.Context, _ *v2.ResourceId, pToken *pagina
 		userResources = append(userResources, userResource)
 	}
 
-	var anno annotations.Annotations
-	anno.WithRateLimiting(rl)
+	outAnnotations.WithRateLimiting(rateLimitData)
 
-	return userResources, next, anno, nil
+	return userResources, next, outAnnotations, nil
 }
 
 // Entitlements always returns an empty slice for users.
@@ -63,7 +66,10 @@ func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, pTo
 
 	user, rateLimitData, err := b.client.RetrieveUserData(ctx, userResource.Id.Resource)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("cannot retrieve user: %w", err)
+		if rateLimitData != nil {
+			outAnnotations.WithRateLimiting(rateLimitData)
+		}
+		return nil, "", outAnnotations, fmt.Errorf("cannot retrieve user: %w", err)
 	}
 	outAnnotations.WithRateLimiting(rateLimitData)
 
@@ -83,7 +89,10 @@ func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, pTo
 		// for which the user has at least one Job with it.
 		userJobPermissions, rateLimitData, err := b.client.GetJobPermissionsOfAUser(ctx, &tokens, user.ID)
 		if err != nil {
-			return nil, "", nil, err
+			if rateLimitData != nil {
+				outAnnotations.WithRateLimiting(rateLimitData)
+			}
+			return nil, "", outAnnotations, err
 		}
 		outAnnotations.WithRateLimiting(rateLimitData)
 
@@ -107,7 +116,10 @@ func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, pTo
 		// These are Job Permissions that will be granted to the user when a job is created in a particular Department/Office combination.
 		userFutureJobPermissions, rateLimitData, err := b.client.GetFutureJobPermissionsOfAUser(ctx, &tokens, user.ID)
 		if err != nil {
-			return nil, "", nil, err
+			if rateLimitData != nil {
+				outAnnotations.WithRateLimiting(rateLimitData)
+			}
+			return nil, "", outAnnotations, err
 		}
 		outAnnotations.WithRateLimiting(rateLimitData)
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -79,7 +79,10 @@ func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, _ *
 			return nil, "", nil, err
 		}
 
-		uniqueUserRoleIDs := extractUniqueUserRolesIDs(userJobPermissions)
+		uniqueUserRoleIDs, err := extractUniqueUserRolesIDs(userJobPermissions)
+		if err != nil {
+			return nil, "", nil, err
+		}
 		for _, userRoleID := range uniqueUserRoleIDs {
 			roleResource := &v2.Resource{
 				Id: &v2.ResourceId{
@@ -92,7 +95,29 @@ func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, _ *
 			roleGrants = append(roleGrants, membershipGrant)
 		}
 
-		// TODO: Include the Grants for Future Jobs? Analyze.
+		// Retrieves the list of 'Future Job Permissions' assigned to the user.
+		// These are Job Permissions that will be granted to the user when a job is created in a particular Department/Office combination.
+		userFutureJobPermissions, err := b.client.GetFutureJobPermissionsOfAUser(ctx, user.ID)
+		if err != nil {
+			return nil, "", nil, err
+		}
+
+		uniqueUserRoleIDs, err = extractUniqueUserRolesIDs(userFutureJobPermissions)
+		if err != nil {
+			return nil, "", nil, err
+		}
+		for _, userRoleID := range uniqueUserRoleIDs {
+			futureRoleUserID := fmt.Sprintf("future-job:%d", userRoleID)
+			roleResource := &v2.Resource{
+				Id: &v2.ResourceId{
+					ResourceType: roleResourceType.Id,
+					Resource:     futureRoleUserID,
+				},
+			}
+
+			membershipGrant := grant.NewGrant(roleResource, rolePermissionName, userID)
+			roleGrants = append(roleGrants, membershipGrant)
+		}
 	}
 
 	return roleGrants, "", nil, nil

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -62,10 +62,10 @@ func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, pTo
 	}
 
 	user, rateLimitData, err := b.client.RetrieveUserData(ctx, userResource.Id.Resource)
-	outAnnotations.WithRateLimiting(rateLimitData)
 	if err != nil {
-		return nil, "", outAnnotations, fmt.Errorf("cannot retrieve user: %w", err)
+		return nil, "", nil, fmt.Errorf("cannot retrieve user: %w", err)
 	}
+	outAnnotations.WithRateLimiting(rateLimitData)
 
 	// If the user is a Site Admin, it should have that Grant and skip the other ones.
 	if user.SiteAdmin {
@@ -82,11 +82,10 @@ func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, pTo
 		// All the Job Permissions of the user will be requested in order to create a grant for any role
 		// for which the user has at least one Job with it.
 		userJobPermissions, rateLimitData, err := b.client.GetJobPermissionsOfAUser(ctx, &tokens, user.ID)
-		outAnnotations = annotations.Annotations{}
-		outAnnotations.WithRateLimiting(rateLimitData)
 		if err != nil {
-			return nil, "", outAnnotations, err
+			return nil, "", nil, err
 		}
+		outAnnotations.WithRateLimiting(rateLimitData)
 
 		uniqueUserRoleIDs, err := extractUniqueUserRolesIDs(userJobPermissions)
 		if err != nil {
@@ -107,11 +106,10 @@ func (b *userBuilder) Grants(ctx context.Context, userResource *v2.Resource, pTo
 		// Retrieves the list of 'Future Job Permissions' assigned to the user.
 		// These are Job Permissions that will be granted to the user when a job is created in a particular Department/Office combination.
 		userFutureJobPermissions, rateLimitData, err := b.client.GetFutureJobPermissionsOfAUser(ctx, &tokens, user.ID)
-		outAnnotations = annotations.Annotations{}
-		outAnnotations.WithRateLimiting(rateLimitData)
 		if err != nil {
-			return nil, "", outAnnotations, err
+			return nil, "", nil, err
 		}
+		outAnnotations.WithRateLimiting(rateLimitData)
 
 		uniqueUserRoleIDs, err = extractUniqueUserRolesIDs(userFutureJobPermissions)
 		if err != nil {


### PR DESCRIPTION
#### Description

- [ ] Bug fix
- [x] New feature

The future Jobs Permissions list is retrieved now when syncing data from GH.
New entitlements included to be able to represent the assignment of a Future Job Permission (a role that will be granted when a new Job is created).



#### Useful links:
- [BB-664](https://conductorone.atlassian.net/browse/BB-664)
- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)


[BB-664]: https://conductorone.atlassian.net/browse/BB-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ