### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-greenhouse/main.go
+++ b/cmd/baton-greenhouse/main.go
@@ -46,7 +46,7 @@ func getConnector(ctx context.Context, ghc *cfg.Greenhouse) (types.ConnectorServ
 		return nil, err
 	}
 
-	cb, err := connector.New(ctx, ghc.On_behalf_of_email, ghc.Username)
+	cb, err := connector.New(ctx, ghc.On_behalf_of_email, ghc.Username, ghc.BaseUrl)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/cmd/test-server/gh-test-server.go
+++ b/cmd/test-server/gh-test-server.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -821,8 +822,8 @@ func main() {
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  120 * time.Second,
 	}
-	err := server.ListenAndServe()
-	if err != nil {
-		log.Fatalf("Could not start server: %s\n", err)
+	if err := server.ListenAndServe(); err != nil {
+		log.Printf("Could not start server: %s\n", err)
+		os.Exit(1)
 	}
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	baseURL = "https://harvest.greenhouse.io"
+	defaultBaseURL = "https://harvest.greenhouse.io"
 
 	usersEPv1                    = "v1/users"
 	userRolesEPv1                = "v1/user_roles"
@@ -30,6 +30,7 @@ type GreenhouseClient struct {
 	user            string
 	onBehalfOfEmail string
 	httpClient      *uhttp.BaseHttpClient
+	baseURL         string
 }
 
 func makeAuthorization(user string) string {
@@ -40,7 +41,7 @@ func makeAuthorization(user string) string {
 
 // ListUsers implemented based on the docs https://developers.greenhouse.io/harvest.html#get-list-users.
 func (c *GreenhouseClient) ListUsers(ctx context.Context, next string) ([]models.User, *v2.RateLimitDescription, string, error) {
-	joinedURL, err := url.JoinPath(baseURL, usersEPv1)
+	joinedURL, err := url.JoinPath(c.baseURL, usersEPv1)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -107,7 +108,7 @@ func (c *GreenhouseClient) CreateUserAccount(ctx context.Context, onBehalfOfID i
 		"send_email_invite": true,
 	}
 
-	endpoint, err := url.JoinPath(baseURL, usersEPv1)
+	endpoint, err := url.JoinPath(c.baseURL, usersEPv1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to join path for user creation: %w", err)
 	}
@@ -142,7 +143,7 @@ func (c *GreenhouseClient) RevokeUserSiteAdmin(ctx context.Context, id int) erro
 		"level": "basic",
 	}
 
-	endpoint, err := url.JoinPath(baseURL, "v1/users/permission_level")
+	endpoint, err := url.JoinPath(c.baseURL, "v1/users/permission_level")
 	if err != nil {
 		return fmt.Errorf("failed to join path for revoke: %w", err)
 	}
@@ -167,7 +168,7 @@ func (c *GreenhouseClient) RevokeUserSiteAdmin(ctx context.Context, id int) erro
 
 // GetUserByEmail retrieves a user by their email address.
 func (c *GreenhouseClient) GetUserByEmail(ctx context.Context, email string) (*models.User, error) {
-	endpoint, err := url.JoinPath(baseURL, usersEPv1)
+	endpoint, err := url.JoinPath(c.baseURL, usersEPv1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build URL: %w", err)
 	}
@@ -212,7 +213,7 @@ func (c *GreenhouseClient) GetJobPermissionsOfAUser(ctx context.Context, tokens 
 		return nil, nil, nil
 	}
 
-	endpointURL, err := url.JoinPath(baseURL, fmt.Sprintf(userJobPermissionsEPv1, userID))
+	endpointURL, err := url.JoinPath(c.baseURL, fmt.Sprintf(userJobPermissionsEPv1, userID))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -269,7 +270,7 @@ func (c *GreenhouseClient) GetFutureJobPermissionsOfAUser(ctx context.Context, t
 		return nil, nil, nil
 	}
 
-	endpointURL, err := url.JoinPath(baseURL, fmt.Sprintf(userFutureJobPermissionsEPv1, userID))
+	endpointURL, err := url.JoinPath(c.baseURL, fmt.Sprintf(userFutureJobPermissionsEPv1, userID))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -320,7 +321,7 @@ func (c *GreenhouseClient) ListUserRoles(ctx context.Context, nextPageURL string
 	var userRoles []models.UserRole
 	var rateLimitData v2.RateLimitDescription
 
-	endpointURL, err := url.JoinPath(baseURL, userRolesEPv1)
+	endpointURL, err := url.JoinPath(c.baseURL, userRolesEPv1)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -363,7 +364,7 @@ func (c *GreenhouseClient) RetrieveUserData(ctx context.Context, userID string) 
 	var userData *models.User
 	var rateLimitData v2.RateLimitDescription
 
-	endpointURL, err := url.JoinPath(baseURL, usersEPv1, userID)
+	endpointURL, err := url.JoinPath(c.baseURL, usersEPv1, userID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -449,15 +450,20 @@ func (c *GreenhouseClient) doRequest(
 }
 
 // New creates a new GreenhouseClient with the given credentials.
-func New(ctx context.Context, username, onBehalfOfEmail string) (*GreenhouseClient, error) {
+func New(ctx context.Context, username, onBehalfOfEmail, baseURL string) (*GreenhouseClient, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
+	}
+
+	if baseURL == "" {
+		baseURL = defaultBaseURL
 	}
 
 	return &GreenhouseClient{
 		user:            username,
 		onBehalfOfEmail: onBehalfOfEmail,
 		httpClient:      uhttp.NewBaseHttpClient(httpClient),
+		baseURL:         baseURL,
 	}, nil
 }

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -6,9 +6,10 @@ import "reflect"
 type Greenhouse struct {
 	Username string `mapstructure:"username"`
 	On_behalf_of_email string `mapstructure:"on_behalf_of_email"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
-func (c* Greenhouse) findFieldByTag(tagValue string) (any, bool) {
+func (c *Greenhouse) findFieldByTag(tagValue string) (any, bool) {
 	v := reflect.ValueOf(c).Elem() // Dereference pointer to struct
 	t := v.Type()
 
@@ -40,11 +41,13 @@ func (c *Greenhouse) GetString(fieldName string) string {
 	if !ok {
 		return ""
 	}
-	t, ok := v.(string)
-	if !ok {
-		panic("wrong type")
+	if t, ok := v.(string); ok {
+		return t
 	}
-	return t
+	if t, ok := v.([]byte); ok {
+		return string(t)
+	}
+	panic("wrong type")
 }
 
 func (c *Greenhouse) GetInt(fieldName string) int {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Greenhouse API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Greenhouse API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,10 @@ var (
 		field.WithDisplayName("On behalf of"),
 		field.WithDescription("Email of the Site Admin user"),
 	)
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Greenhouse API URL (for testing)"),
+	)
 
 	// FieldRelationships defines relationships between the fields listed in
 	// ConfigurationFields that can be automatically validated. For example, a
@@ -31,6 +35,7 @@ var Config = field.NewConfiguration(
 	[]field.SchemaField{
 		usernameField,
 		onBehalfOfField,
+		BaseURLField,
 	},
 	field.WithConnectorDisplayName("Greenhouse"),
 	field.WithHelpUrl("/docs/baton/greenhouse"),

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -80,8 +80,8 @@ func (d *Connector) Validate(_ context.Context) (annotations.Annotations, error)
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, onBehalfOf, username string) (*Connector, error) {
-	c, err := client.New(ctx, username, onBehalfOf)
+func New(ctx context.Context, onBehalfOf, username, baseURL string) (*Connector, error) {
+	c, err := client.New(ctx, username, onBehalfOf, baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create a connector, error: %w", err)
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-greenhouse/main.go,pkg/client/client.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-greenhouse --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.