### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/convert.go
+++ b/pkg/connector/convert.go
@@ -17,15 +17,18 @@ func parseIntoUserResource(user models.User) (*v2.Resource, error) {
 	}
 
 	options := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
 		resource.WithEmployeeID(user.EmployeeID),
 		resource.WithEmail(user.PrimaryEmailAddress, true),
 	}
 
+	resourceOptions := []resource.ResourceOption{
+		resource.WithResourceProfile(profile),
+	}
+
 	if user.Disabled {
-		options = append(options, resource.WithStatus(v2.UserTrait_Status_STATUS_DISABLED))
+		resourceOptions = append(resourceOptions, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_DISABLED, ""))
 	} else {
-		options = append(options, resource.WithStatus(v2.UserTrait_Status_STATUS_ENABLED))
+		resourceOptions = append(resourceOptions, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""))
 	}
 
 	userResource, err := resource.NewUserResource(
@@ -33,6 +36,7 @@ func parseIntoUserResource(user models.User) (*v2.Resource, error) {
 		userResourceType,
 		user.ID,
 		options,
+		resourceOptions...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot make user resource from user «%s %s» (id «%d»)", user.FirstName, user.LastName, user.ID)

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -172,15 +172,14 @@ func createRoleResource(roleID, name, roleType string) (*v2.Resource, error) {
 		"type": roleType,
 	}
 
-	roleTraits := []resourceSdk.RoleTraitOption{
-		resourceSdk.WithRoleProfile(profile),
-	}
+	roleTraits := []resourceSdk.RoleTraitOption{}
 
 	return resourceSdk.NewRoleResource(
 		name,
 		roleResourceType,
 		roleID,
 		roleTraits,
+		resourceSdk.WithResourceProfile(profile),
 	)
 }
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -218,13 +218,13 @@ func (b *userBuilder) CreateAccount(
 		createdUser.ID,
 		[]resource.UserTraitOption{
 			resource.WithEmail(email, true),
-			resource.WithUserProfile(map[string]interface{}{
-				"email":      email,
-				"first_name": firstName,
-				"last_name":  lastName,
-				"id":         createdUser.ID,
-			}),
 		},
+		resource.WithResourceProfile(map[string]interface{}{
+			"email":      email,
+			"first_name": firstName,
+			"last_name":  lastName,
+			"id":         createdUser.ID,
+		}),
 	)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to build resource: %w", err)


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
